### PR TITLE
Remove redpanda_cluster_partition_leader_id from Partition Balance

### DIFF
--- a/grafana-dashboards/Redpanda-Ops-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Ops-Dashboard.json
@@ -781,19 +781,6 @@
           "range": true,
           "refId": "A",
           "step": 10
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "100 - (stddev(count(redpanda_cluster_partition_leader_id{redpanda_cloud_data_cluster_name=~\"[[data_cluster]]\"} offset  1d) by (instance)) / \navg(count(redpanda_cluster_partition_leader_id{redpanda_cloud_data_cluster_name=~\"[[data_cluster]]\"} offset  1d) by (instance)) * 100)",
-          "hide": true,
-          "interval": "",
-          "intervalFactor": 10,
-          "legendFormat": "Yesterday cluster sum",
-          "refId": "B"
         }
       ],
       "title": "Partition Balance",


### PR DESCRIPTION
Given the metric `redpanda_cluster_partition_leader_id` isn't exposed via `/public_metrics`, we shouldn't use it.