### PR TITLE
Storage Saturation disk space chart

### DIFF
--- a/grafana-dashboards/Redpanda-Ops-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Ops-Dashboard.json
@@ -4677,8 +4677,8 @@
           "calcs": [
             "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "right",
+          "displayMode": "list",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {

--- a/grafana-dashboards/Redpanda-Ops-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Ops-Dashboard.json
@@ -4601,6 +4601,108 @@
       ],
       "title": "Leadership Transfers",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Available storage for Redpanda clusters",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 95
+      },
+      "id": 23763572043,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "1 - redpanda_storage_disk_free_bytes{}/redpanda_storage_disk_total_bytes{}",
+          "instant": false,
+          "legendFormat": "{{ instance }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Storage Saturation",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/grafana-dashboards/Redpanda-Ops-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Ops-Dashboard.json
@@ -4694,9 +4694,9 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "1 - redpanda_storage_disk_free_bytes{}/redpanda_storage_disk_total_bytes{}",
+          "expr": "1 - sum(redpanda_storage_disk_free_bytes{instance=~\"[[node]]\",exported_instance=~\"[[exported_node]]\",redpanda_cloud_data_cluster_name=~\"[[data_cluster]]\"}) by ([[aggr_criteria]])/sum(redpanda_storage_disk_total_bytes{instance=~\"[[node]]\",exported_instance=~\"[[exported_node]]\",redpanda_cloud_data_cluster_name=~\"[[data_cluster]]\"}) by ([[aggr_criteria]])",
           "instant": false,
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "Pod: {{pod}}, Node: {{instance}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
Add a graph for storage saturation / remaining disk space per-broker to the Ops Dashboard, based off of the one in the Redpanda Cloud dashboard. The bottom of the dashboard now looks like this:

<img width="1145" alt="image" src="https://github.com/redpanda-data/observability/assets/594093/3f40e882-d297-4bfb-ac9f-7d54b04252e8">
