### PR TITLE
rpcn: fix per min computations

### DIFF
--- a/grafana-dashboards/Redpanda-Connect-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Connect-Dashboard.json
@@ -596,7 +596,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(batch_created[5m]))*300",
+          "expr": "sum(rate(batch_created[5m]))*60",
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -692,7 +692,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(output_sent[5m])*300",
+          "expr": "rate(output_sent[5m])*60",
           "instant": false,
           "legendFormat": "{{path}}",
           "range": true,
@@ -976,7 +976,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(processor_batch_received[5m])*300",
+          "expr": "rate(processor_batch_received[5m])*60",
           "instant": false,
           "legendFormat": "{{path}}",
           "range": true,
@@ -1071,7 +1071,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(processor_batch_sent[5m])*300",
+          "expr": "rate(processor_batch_sent[5m])*60",
           "instant": false,
           "legendFormat": "{{path}}",
           "range": true,
@@ -1355,7 +1355,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(processor_received[5m])*300",
+          "expr": "rate(processor_received[5m])*60",
           "instant": false,
           "legendFormat": "{{path}}",
           "range": true,
@@ -1450,7 +1450,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(processor_sent[5m])*300",
+          "expr": "rate(processor_sent[5m])*60",
           "instant": false,
           "legendFormat": "{{path}}",
           "range": true,


### PR DESCRIPTION
Fix per min computations for Redpanda connect dashboard

The 5m in the rate is a lookback time to smooth the curve, but the result is still a rate ("#/second"), so the conversion multiplier to have a "#/minute" should be always 60 , not 300