### PR TITLE
fix description for Kafka partition offset balance deviation

### DIFF
--- a/grafana-dashboards/Redpanda-Ops-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Ops-Dashboard.json
@@ -783,7 +783,7 @@
           "step": 10
         }
       ],
-      "title": "Partition Balance",
+      "title": "Partition Offset Balance Deviation",
       "type": "stat"
     },
     {


### PR DESCRIPTION
The original description is misleading. It implies how partition replicas are distributed across brokers, but it's not the case. This commit suggests a new description but I'm happy to accept any other good ideas.