### PR TITLE
rpcn: add missing datasource

### DIFF
--- a/grafana-dashboards/Redpanda-Connect-Dashboard.json
+++ b/grafana-dashboards/Redpanda-Connect-Dashboard.json
@@ -1466,7 +1466,26 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-3h",


### PR DESCRIPTION
Without this all the graphs don't show up by default because there is no
link to the datasource variable - at least on the cloud example.
